### PR TITLE
feat: add base styles to deposit form button and input

### DIFF
--- a/src/app/[deployment]/[vault]/(depositor)/deposit/page.tsx
+++ b/src/app/[deployment]/[vault]/(depositor)/deposit/page.tsx
@@ -23,6 +23,7 @@ export default async function DepositPage({ params }: { params: { deployment: st
   return (
     <PageLayout>
       <VaultApprove deployment={deployment} comptroller={comptroller} denominationAsset={denominationAsset} />
+      <div className="border-solid border-t" />
       <VaultBuyShares deployment={deployment} comptroller={comptroller} denominationAsset={denominationAsset} />
     </PageLayout>
   );

--- a/src/components/VaultApprove.tsx
+++ b/src/components/VaultApprove.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Title } from "./Title";
+import { Button } from "./ui/button";
 import { type Deployment, getNetworkByDeployment } from "@/lib/consts";
 import { useAllowance } from "@/lib/hooks/useAllowance";
 import { z } from "@/lib/zod";
@@ -10,7 +11,6 @@ import { useForm } from "react-hook-form";
 import { type Address, parseAbi, zeroAddress } from "viem";
 import { useAccount, useContractWrite } from "wagmi";
 import { z as zz } from "zod";
-import { Button } from "./ui/button";
 
 interface VaultApproveProps {
   deployment: Deployment;

--- a/src/components/VaultApprove.tsx
+++ b/src/components/VaultApprove.tsx
@@ -10,6 +10,7 @@ import { useForm } from "react-hook-form";
 import { type Address, parseAbi, zeroAddress } from "viem";
 import { useAccount, useContractWrite } from "wagmi";
 import { z as zz } from "zod";
+import { Button } from "./ui/button";
 
 interface VaultApproveProps {
   deployment: Deployment;
@@ -56,13 +57,13 @@ export function VaultApprove({ deployment, comptroller, denominationAsset }: Vau
   };
 
   return (
-    <form name="approve" onSubmit={handleSubmit(onSubmit)}>
+    <form name="approve" onSubmit={handleSubmit(onSubmit)} className="flex-col space-y-4 my-8">
       <Title appearance="primary">Step 1: Approve </Title>
       Currently approved amount: {approvedAmount.toString()}
       <br />
-      <input {...register("amount")} />
+      <input {...register("amount")} className="h-10 rounded p-2" />
       <br />
-      <button type="submit">Submit</button>
+      <Button type="submit">Submit</Button>
     </form>
   );
 }

--- a/src/components/VaultBuyShares.tsx
+++ b/src/components/VaultBuyShares.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Title } from "./Title";
+import { Button } from "./ui/button";
 import { type Deployment, getNetworkByDeployment } from "@/lib/consts";
 import { useAllowance } from "@/lib/hooks/useAllowance";
 import { useBalanceOf } from "@/lib/hooks/useBalanceOf";
@@ -12,7 +13,6 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { type Address, zeroAddress } from "viem";
 import { useAccount, useContractWrite } from "wagmi";
-import { Button } from "./ui/button";
 
 interface VaultBuySharesProps {
   deployment: Deployment;

--- a/src/components/VaultBuyShares.tsx
+++ b/src/components/VaultBuyShares.tsx
@@ -12,6 +12,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { type Address, zeroAddress } from "viem";
 import { useAccount, useContractWrite } from "wagmi";
+import { Button } from "./ui/button";
 
 interface VaultBuySharesProps {
   deployment: Deployment;
@@ -82,14 +83,14 @@ export function VaultBuyShares({ deployment, comptroller, denominationAsset }: V
   };
 
   return accountBalance === undefined ? null : (
-    <form name="buyShares" onSubmit={handleSubmit(onSubmit)}>
+    <form name="buyShares" onSubmit={handleSubmit(onSubmit)} className="flex-col space-y-4 my-8">
       <Title appearance="primary">Step 2: Deposit</Title>
       Denomination asset balance: {accountBalance?.toString()}
       Currently approved amount: {approvedAmount?.toString()}
       <br />
-      <input {...register("amount")} />
+      <input {...register("amount")} className="h-10 rounded p-2" />
       <br />
-      <button type="submit">Submit</button>
+      <Button type="submit">Submit</Button>
     </form>
   );
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds UI improvements to the deposit page of a Vault, including the addition of styled buttons and input fields.

### Detailed summary
- Add `Button` component import to `VaultApprove` and `VaultBuyShares`
- Replace plain HTML buttons with `Button` components in `VaultApprove` and `VaultBuyShares`
- Add `className` to `form` elements in `VaultApprove` and `VaultBuyShares`
- Add `className` to `input` elements in `VaultApprove` and `VaultBuyShares`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->