### PR TITLE
refactor: update contract types

### DIFF
--- a/src/app/[deployment]/[vault]/(tabs)/@configuration/page.tsx
+++ b/src/app/[deployment]/[vault]/(tabs)/@configuration/page.tsx
@@ -10,19 +10,8 @@ import { AllowedDepositRecipintsPolicy } from "@/components/policies/AllowedDepo
 import { AllowedSharesTransferRecipientsPolicy } from "@/components/policies/AllowedSharesTransferRecipientsPolicy";
 import { MinMaxInvestmentPolicy } from "@/components/policies/MinMaxInvestmentPolicy";
 import { Skeleton } from "@/components/ui/skeleton";
-import {
-  ALLOWED_DEPOSIT_RECIPIENTS_POLICY,
-  ALLOWED_SHARES_TRANSFER_RECIPIENTS_POLICY,
-  type Deployment,
-  ENTRANCE_RATE_BURN_FEE,
-  ENTRANCE_RATE_DIRECT_FEE,
-  EXIT_RATE_BURN_FEE,
-  EXIT_RATE_DIRECT_FEE,
-  MANAGEMENT_FEE,
-  MIN_MAX_INVESTMENT_POLICY,
-  MIN_SHARES_SUPPLY_FEE,
-  PERFORMANCE_FEE,
-} from "@/lib/consts";
+import type { Deployment } from "@/lib/consts";
+import { getContract } from "@/lib/consts";
 import { assertParams } from "@/lib/params";
 import { getPublicClientForDeployment } from "@/lib/rpc";
 import { z } from "@/lib/zod";
@@ -44,19 +33,19 @@ function getFeeComponent({
   fee: Address;
 }) {
   switch (fee) {
-    case EXIT_RATE_BURN_FEE:
+    case getContract(deployment, "ExitRateBurnFee"):
       return <ExitRateBurnFee fee={fee} deployment={deployment} comptrollerProxy={comptrollerProxy} />;
-    case EXIT_RATE_DIRECT_FEE:
+    case getContract(deployment, "ExitRateDirectFee"):
       return <ExitRateDirectFee fee={fee} deployment={deployment} comptrollerProxy={comptrollerProxy} />;
-    case ENTRANCE_RATE_BURN_FEE:
+    case getContract(deployment, "EntranceRateBurnFee"):
       return <EntranceRateBurnFee fee={fee} deployment={deployment} comptrollerProxy={comptrollerProxy} />;
-    case ENTRANCE_RATE_DIRECT_FEE:
+    case getContract(deployment, "EntranceRateDirectFee"):
       return <EntranceRateDirectFee fee={fee} deployment={deployment} comptrollerProxy={comptrollerProxy} />;
-    case MANAGEMENT_FEE:
+    case getContract(deployment, "ManagementFee"):
       return <ManagementFee fee={fee} deployment={deployment} comptrollerProxy={comptrollerProxy} />;
-    case PERFORMANCE_FEE:
+    case getContract(deployment, "PerformanceFee"):
       return <PerformanceFee fee={fee} deployment={deployment} comptrollerProxy={comptrollerProxy} />;
-    case MIN_SHARES_SUPPLY_FEE:
+    case getContract(deployment, "MinSharesSupplyFee"):
       return <MinSharesSupplyFee fee={fee} deployment={deployment} comptrollerProxy={comptrollerProxy} />;
     default:
       return <>Unknown fee</>;
@@ -73,11 +62,11 @@ function getPolicyComponent({
   policy: Address;
 }) {
   switch (policy) {
-    case ALLOWED_DEPOSIT_RECIPIENTS_POLICY:
+    case getContract(deployment, "AllowedDepositRecipientsPolicy"):
       return (
         <AllowedDepositRecipintsPolicy policy={policy} deployment={deployment} comptrollerProxy={comptrollerProxy} />
       );
-    case ALLOWED_SHARES_TRANSFER_RECIPIENTS_POLICY:
+    case getContract(deployment, "AllowedSharesTransferRecipientsPolicy"):
       return (
         <AllowedSharesTransferRecipientsPolicy
           policy={policy}
@@ -85,7 +74,7 @@ function getPolicyComponent({
           comptrollerProxy={comptrollerProxy}
         />
       );
-    case MIN_MAX_INVESTMENT_POLICY:
+    case getContract(deployment, "MinMaxInvestmentPolicy"):
       return <MinMaxInvestmentPolicy policy={policy} deployment={deployment} comptrollerProxy={comptrollerProxy} />;
     default:
       return <>Unknown Policy</>;

--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -16,46 +16,74 @@ export function getNetworkByDeployment(deployment: Deployment): Network {
       return "polygon";
   }
 }
-export const EXIT_RATE_BURN_FEE = "0x06b13918E988D1314dA1a9dA4C0cdE5fe994364a";
-export const EXIT_RATE_DIRECT_FEE = "0x3a09d11C20AA1aD38C77B4f426901d3427f73fBE";
-export const ENTRANCE_RATE_BURN_FEE = "0xcdec5bbecc6d2c004d5378a63a3c484c2643ed9d";
-export const ENTRANCE_RATE_DIRECT_FEE = "0xfb8df7d5e320020cd8047226b81cf6d68f3e3c19";
-export const PERFORMANCE_FEE = "0xfeDC73464Dfd156d30F6524654a5d56E766DA0c3";
-export const MANAGEMENT_FEE = "0xFaF2c3DB614E9d38fE05EDc634848BE7Ff0542B9";
-export const MIN_SHARES_SUPPLY_FEE = "0xbc9da8edde80ffb1294852d23ee1b385ea2d4929";
-
-export const ALLOWED_DEPOSIT_RECIPIENTS_POLICY = "0xA66BAAa0cCb6468C5A2cB61f5D672C7bA0440Ee1";
-export const MIN_MAX_INVESTMENT_POLICY = "0xebdadFC929c357d12281118828AeA556db5be30C";
-export const ALLOWED_SHARES_TRANSFER_RECIPIENTS_POLICY = "0xebE37e43bC6b3AacfE318d6906fc80C4a2a7505A";
-export const ALLOWED_ADAPTER_INCOMING_ASSETS = "0x2f0e55830a173d845a886fd574f01a039a07fc37";
 
 type Contracts = {
-  Usdc: Address;
-  ExternalPositionFactory: Address;
-  FundValueCalculatorRouter: Address;
+  AllowedDepositRecipientsPolicy: Address;
+  AllowedSharesTransferRecipientsPolicy: Address;
   Dispatcher: Address;
+  ExternalPositionFactory: Address;
+  ExitRateBurnFee: Address;
+  ExitRateDirectFee: Address;
+  EntranceRateBurnFee: Address;
+  EntranceRateDirectFee: Address;
+  FundValueCalculatorRouter: Address;
+  ManagementFee: Address;
+  MinSharesSupplyFee: Address;
+  MinMaxInvestmentPolicy: Address;
+  PerformanceFee: Address;
+  Usdc: Address;
 };
 
 const contracts: {
   [deployment in Deployment]: Contracts;
 } = {
   ethereum: {
-    Usdc: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+    AllowedDepositRecipientsPolicy: "0xa66baaa0ccb6468c5a2cb61f5d672c7ba0440ee1",
+    AllowedSharesTransferRecipientsPolicy: "0xebe37e43bc6b3aacfe318d6906fc80c4a2a7505a",
     Dispatcher: "0xc3dc853dd716bd5754f421ef94fdcbac3902ab32",
     ExternalPositionFactory: "0x0aacb782205dde9eff4862ace9849dce1ca3409f",
+    EntranceRateBurnFee: "0xcdec5bbecc6d2c004d5378a63a3c484c2643ed9d",
+    EntranceRateDirectFee: "0xfb8df7d5e320020cd8047226b81cf6d68f3e3c19",
+    ExitRateBurnFee: "0x06b13918E988D1314dA1a9dA4C0cdE5fe994364a",
+    ExitRateDirectFee: "0x3a09d11c20aa1ad38c77b4f426901d3427f73fbe",
     FundValueCalculatorRouter: "0x7c728cd0CfA92401E01A4849a01b57EE53F5b2b9",
+    ManagementFee: "0xfaf2c3db614e9d38fe05edc634848be7ff0542b9",
+    MinSharesSupplyFee: "0xbc9da8edde80ffb1294852d23ee1b385ea2d4929",
+    MinMaxInvestmentPolicy: "0xebdadfc929c357d12281118828aea556db5be30c",
+    PerformanceFee: "0xfedc73464dfd156d30f6524654a5d56e766da0c3",
+    Usdc: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
   },
   polygon: {
-    Usdc: "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+    AllowedDepositRecipientsPolicy: "0xe1853502e2ea2b7c14c5e89169c63065f5a459ff",
+    AllowedSharesTransferRecipientsPolicy: "0x3b6913a8ed4595919a6b4a9022208cede20194bd",
     Dispatcher: "0x2e25271297537b8124b8f883a92ffd95c4032733",
     ExternalPositionFactory: "0x067eeea753aba0ddecca0b80bbb8b7572bf6580d",
+    EntranceRateBurnFee: "0x01460ba35cb6f847d65c5eee124e7e9e10055f16",
+    EntranceRateDirectFee: "0x88c9a11c7bb8bc274388d0db864ab87c14fb78b8",
+    ExitRateBurnFee: "0x0bbb9635d12a9c022b647f379224d88874d37879",
+    ExitRateDirectFee: "0xc5c7f7c6e5e2db074d96b440d30d7aab2c99b848",
     FundValueCalculatorRouter: "0xd70389a7d6171e1dba6c3df4db7331811fd93f08",
+    PerformanceFee: "0xbc63afe28c66a6279bd3a55a4d0d3ab61f479bdf",
+    ManagementFee: "0x97f13b3040a565be791d331b0edd4b1b58dbd843",
+    MinSharesSupplyFee: "0xeb45b91d582ae383e750a1626a97f854a9df19a3",
+    MinMaxInvestmentPolicy: "0x8ac04e34d9c1d0bd5a440157538cc6fbb0dbbc9a",
+    Usdc: "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
   },
   testnet: {
-    Usdc: "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+    AllowedDepositRecipientsPolicy: "0x7656970e350e79ce550dd3051d4014373371df53",
+    AllowedSharesTransferRecipientsPolicy: "0x0acfeb85b8dc2db3aa34f93151b7a494b84a99bc",
     Dispatcher: "0xd77231f355c6790441c1fb95a2e2ef916d5b3d84",
+    EntranceRateBurnFee: "0x722e252e5140a46530cc3f4534eb1561851b8b57",
+    EntranceRateDirectFee: "0xc1755fb4b9157186aecf0775c4f6c3a0dd0ea7af",
     ExternalPositionFactory: "0x30ca263f9a3780c70530ffaf0ccc162ae3eba993",
+    ExitRateBurnFee: "0x00ded19f9f8e512dc8041f5b52b20d53ebdb69f8",
+    ExitRateDirectFee: "0xaed3e269898de65715f71d88f7dcb7986d3f31b0",
     FundValueCalculatorRouter: "0xb9c46d50d25808014b9371a91f44e602ecda7f0f",
+    ManagementFee: "0x4a95185896adce31a8cdfaaa2832decc3d20dc2c",
+    MinSharesSupplyFee: "0x8a2cfb231be7c229209dc41e62def7756a6088a2",
+    MinMaxInvestmentPolicy: "0xd2dbb1d5222200b94f4aea2618d88cc33146987b",
+    PerformanceFee: "0xf1fcba510713355d7504b87a163420a2bd116a4b",
+    Usdc: "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
   },
 };
 


### PR DESCRIPTION
Refactor how fees and policy constants are exported

<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes several constants and replaces them with function calls to retrieve contract addresses. It also updates the contract address mappings in `consts.ts`.

### Detailed summary
- Removed several constants related to contract addresses
- Added `getContract` function to retrieve contract addresses
- Updated contract address mappings in `consts.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->